### PR TITLE
Add Python JSON Parsing

### DIFF
--- a/python.py
+++ b/python.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+
+import sys
+import requests
+
+base = "SGD"
+symbols = "MYR"
+
+url = "http://api.fixer.io/latest?symbols={}&base={}".format(symbols, base)
+
+jsonresp = requests.get(url).json()
+
+sys.stdout.write("{}1={}{}\n".format(base, symbols, jsonresp["rates"]["MYR"]))


### PR DESCRIPTION
Supports Python3, as well as Python2. I removed version number since it supports both of them.

requires [Requests][1].

[1]: http://docs.python-requests.org